### PR TITLE
Add LICENSE (MIT) and CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,32 @@
+# HackerBlog Code of Conduct
+
+## Our Pledge
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in HackerBlog a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+Examples of behavior that contributes to creating a positive environment include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior include:
+
+- Harassment, intimidation, or discrimination in any form
+- Public or private insults and derogatory comments
+- Publishing others’ private information without consent
+- Any other conduct that could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+Project maintainers are responsible for clarifying standards of acceptable behavior and enforcing this Code of Conduct fairly and consistently.
+
+## Reporting
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project maintainers at [your-email@example.com]. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
+
+## Enforcement
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned with this Code of Conduct.  
+
+## Attribution
+This Code of Conduct is adapted from the [Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 HacktoberBlog
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Added License and Code of Conduct

### What’s new
- Added `LICENSE` file (MIT License) to clearly define project usage and permissions.
- Added `CODE_OF_CONDUCT.md` (Contributor Covenant v2.1) to establish community guidelines for contributors.

### Why
- LICENSE ensures legal clarity for users and contributors.
- CODE_OF_CONDUCT promotes a safe and welcoming environment, especially important for Hacktoberfest participation.

### Checklist
- [x] LICENSE file added
- [x] CODE_OF_CONDUCT.md added
- [x] Files properly formatted and committed

### Preview
- LICENSE: MIT license
- CODE_OF_CONDUCT.md: Contributor Covenant v2.1

This PR prepares the project for open-source contributions and Hacktoberfest 2025.
